### PR TITLE
Fix typo in plunit.pl.

### DIFF
--- a/plunit.pl
+++ b/plunit.pl
@@ -102,7 +102,7 @@ user:term_expansion(In, Out) :-
 	if_expansion(In, Out).
 
 swi     :- catch(current_prolog_flag(dialect, swi), _, fail), !.
-swi     :- catch(current_prolog_flag(dialect, yap), _, fail).
+yap     :- catch(current_prolog_flag(dialect, yap), _, fail).
 sicstus :- catch(current_prolog_flag(system_type, _), _, fail).
 
 


### PR DESCRIPTION
Set local dialect to swi when prolog flag dialect was set to yap.
